### PR TITLE
Add async GUI launcher and error reporting

### DIFF
--- a/web/gui_home.html
+++ b/web/gui_home.html
@@ -27,6 +27,9 @@
         </div>
     </div>
 
+    <div id="error-display" style="display:none; margin:16px; padding:12px; background:#2d1111; border:1px solid #cc3333; border-radius:6px; color:#ff6666; max-height:300px; overflow-y:auto; font-size:13px;">
+        <h3 style="margin:0 0 8px 0; color:#ff4444;">Error Log</h3>
+    </div>
 
     <script type="text/javascript">
         function runProgram1() {
@@ -62,6 +65,17 @@
 
         function showFileDialog() {
             eel.show_file_dialog();
+        }
+
+        eel.expose(displayError);
+        function displayError(guiName, errorMsg) {
+            var errorDiv = document.getElementById('error-display');
+            var timestamp = new Date().toLocaleTimeString();
+            var entry = document.createElement('div');
+            entry.className = 'error-entry';
+            entry.innerHTML = '<strong>[' + timestamp + '] ' + guiName + '</strong><pre>' + errorMsg + '</pre>';
+            errorDiv.prepend(entry);
+            errorDiv.style.display = 'block';
         }
     </script>
 

--- a/working-example.md
+++ b/working-example.md
@@ -1,0 +1,121 @@
+# YORU Working Environment
+
+## Date
+2026-03-26
+
+## OS
+- Windows 11 Home (10.0.26200)
+
+## Conda
+- Conda version: 26.1.1
+- Environment name: `yoru`
+- Environment location: `C:\Users\kamik\anaconda3\envs\yoru`
+
+## Python
+- Python 3.9.25
+
+## GPU / CUDA
+| Item | Value |
+|------|-------|
+| GPU | NVIDIA GeForce RTX 5070 Ti |
+| GPU Memory | 16,303 MiB |
+| NVIDIA Driver | 581.42 |
+| CUDA (Driver) | 13.0 |
+| CUDA (PyTorch runtime) | 12.8 |
+| cuDNN | 9.10.02 |
+| PyTorch | 2.8.0+cu128 |
+| torchvision | 0.23.0+cu128 |
+
+## Installed Packages
+
+| Package | Version |
+|---------|---------|
+| bottle | 0.13.4 |
+| bottle-websocket | 0.2.9 |
+| certifi | 2026.2.25 |
+| cffi | 2.0.0 |
+| charset-normalizer | 3.4.6 |
+| colorama | 0.4.6 |
+| contourpy | 1.3.0 |
+| cycler | 0.12.1 |
+| dearpygui | 1.11.1 |
+| deprecation | 2.1.0 |
+| Eel | 0.16.0 |
+| exceptiongroup | 1.3.1 |
+| filelock | 3.19.1 |
+| fonttools | 4.60.2 |
+| fsspec | 2025.10.0 |
+| future | 1.0.0 |
+| gevent | 25.9.1 |
+| gevent-websocket | 0.10.1 |
+| gitdb | 4.0.12 |
+| GitPython | 3.1.43 |
+| greenlet | 3.2.4 |
+| hightime | 0.2.2 |
+| idna | 3.11 |
+| ImageIO | 2.37.2 |
+| imgui | 2.0.0 |
+| importlib_resources | 6.5.2 |
+| iniconfig | 2.1.0 |
+| Jinja2 | 3.1.6 |
+| kiwisolver | 1.4.7 |
+| labelImg | 1.8.6 |
+| lazy-loader | 0.5 |
+| lxml | 6.0.2 |
+| MarkupSafe | 3.0.2 |
+| matplotlib | 3.7.5 |
+| mpmath | 1.3.0 |
+| mss | 9.0.1 |
+| munkres | 1.1.4 |
+| networkx | 3.2.1 |
+| nidaqmx | 0.9.0 |
+| numpy | 1.24.4 |
+| opencv-python | 4.10.0.82 |
+| packaging | 26.0 |
+| pandas | 2.0.3 |
+| pillow | 10.3.0 |
+| pip | 26.0.1 |
+| pluggy | 1.6.0 |
+| psutil | 5.9.8 |
+| py-cpuinfo | 9.0.0 |
+| pycparser | 2.23 |
+| pyFirmata | 1.1.0 |
+| pyglet | 2.0.15 |
+| pynput | 1.7.7 |
+| PyOpenGL | 3.1.7 |
+| PyOpenGL-accelerate | 3.1.7 |
+| pyparsing | 3.3.2 |
+| PyQt5 | 5.15.11 |
+| PyQt5-Qt5 | 5.15.2 |
+| PyQt5_sip | 12.17.1 |
+| pyserial | 3.5 |
+| pytest | 7.4.0 |
+| python-dateutil | 2.9.0.post0 |
+| pytz | 2026.1.post1 |
+| PyWavelets | 1.6.0 |
+| pywin32 | 306 |
+| PyYAML | 6.0.1 |
+| requests | 2.32.3 |
+| scikit-image | 0.21.0 |
+| scipy | 1.10.1 |
+| seaborn | 0.13.2 |
+| setuptools | 80.9.0 |
+| six | 1.17.0 |
+| smmap | 5.0.3 |
+| sympy | 1.14.0 |
+| thop | 0.1.1.post2209072238 |
+| tifffile | 2024.8.30 |
+| tomli | 2.4.1 |
+| torch | 2.8.0+cu128 |
+| torchvision | 0.23.0+cu128 |
+| tqdm | 4.66.4 |
+| typing_extensions | 4.15.0 |
+| tzdata | 2025.3 |
+| ultralytics | 8.2.52 |
+| ultralytics-thop | 2.0.0 |
+| urllib3 | 2.6.3 |
+| wheel | 0.45.1 |
+| whichcraft | 0.6.1 |
+| zipp | 3.23.0 |
+| zope.event | 6.0 |
+| zope.interface | 8.0.1 |

--- a/yoru/app.py
+++ b/yoru/app.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import sys
+import threading
 from pathlib import Path
 from tkinter import Tk, filedialog
 
@@ -23,6 +24,28 @@ sys.path.append("../yoru")
 
 default_condition_file_path = "./config/yoru_default.yaml"
 condition_file_path = default_condition_file_path
+
+
+def _run_gui_subprocess(command, gui_name):
+    """GUIサブプロセスを実行し、エラーがあればEel経由でフロントに通知する"""
+    proc = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = proc.communicate()
+    if proc.returncode != 0:
+        error_msg = stderr.strip() if stderr.strip() else stdout.strip()
+        eel.displayError(gui_name, error_msg)
+
+
+def _launch_gui(command, gui_name):
+    """バックグラウンドスレッドでGUIサブプロセスを起動する"""
+    thread = threading.Thread(
+        target=_run_gui_subprocess, args=(command, gui_name), daemon=True
+    )
+    thread.start()
 
 
 def create_default_json():
@@ -57,17 +80,17 @@ def load_condition_file():
 @eel.expose
 def run_cam_gui_YMH():
     global condition_file_path
-    if os.path.isfile(condition_file_path):
-        subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                f"from yoru import realtime_yoru_GUI; realtime_yoru_GUI.main(r'{condition_file_path}')",
-            ],
-            creationflags=subprocess.CREATE_NEW_CONSOLE,
-        )
-    else:
-        print("not find config file")
+    if not os.path.isfile(condition_file_path):
+        eel.displayError("Real-time GUI", "Config file not found: " + condition_file_path)
+        return
+    _launch_gui(
+        [
+            sys.executable,
+            "-c",
+            f"from yoru import realtime_yoru_GUI; realtime_yoru_GUI.main(r'{condition_file_path}')",
+        ],
+        "Real-time GUI",
+    )
 
 
 @eel.expose
@@ -112,25 +135,25 @@ def print_file_path():
 
 @eel.expose
 def run_analysis_gui():
-    subprocess.Popen(
+    _launch_gui(
         [sys.executable, "-c", "from yoru import analysis_GUI; analysis_GUI.main()"],
-        creationflags=subprocess.CREATE_NEW_CONSOLE,
+        "Analysis GUI",
     )
 
 
 @eel.expose
 def run_train_gui():
-    subprocess.Popen(
+    _launch_gui(
         [sys.executable, "-c", "from yoru import train_GUI; train_GUI.main()"],
-        creationflags=subprocess.CREATE_NEW_CONSOLE,
+        "Train GUI",
     )
 
 
 @eel.expose
 def run_evaluate_gui():
-    subprocess.Popen(
+    _launch_gui(
         [sys.executable, "-c", "from yoru import evaluation_GUI; evaluation_GUI.main()"],
-        creationflags=subprocess.CREATE_NEW_CONSOLE,
+        "Evaluate GUI",
     )
 
 


### PR DESCRIPTION
Add front-end error log UI and backend support for reporting GUI subprocess errors. web/gui_home.html: add an error display panel and expose displayError to prepend timestamped error entries. yoru/app.py: introduce threading and helper functions (_run_gui_subprocess and _launch_gui) to run GUI subprocesses on background threads, capture stdout/stderr, and notify the front end via eel.displayError; refactor run_cam_gui_YMH, run_analysis_gui, run_train_gui, and run_evaluate_gui to use the new launcher and add config-file-not-found handling for the real-time GUI. Also add working-example.md documenting the working environment and installed packages.