### PR TITLE
Add ~/.yoru user directory with persistent error/work logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# YORU — Claude Code project guide
+
+YORU is a Windows Python app (DearPyGui GUIs + Ultralytics YOLO) for real-time
+animal-behavior detection.
+
+## Runtime logs — check these first when something fails
+
+Runtime errors and work logs are written to a rotating log file under the
+user's home directory:
+
+- **`~/.yoru/logs/yoru.log`** — every caught GUI error (via
+  `GuiErrorMixin._report_error`), subprocess failures reported by
+  `yoru/app.py`, and CLI-level failures.
+
+When investigating **any** YORU failure, read this file first: it contains the
+full traceback even when the on-screen popup or console only shows a summary.
+
+- The user directory can be relocated with the `YORU_HOME` environment variable
+  (defaults to `~/.yoru`).
+- Logs rotate at 5 MB and keep 3 backups (`yoru.log`, `yoru.log.1`, …).
+
+## User state
+
+- **`~/.yoru/condition_file_log.json`** — remembers the last-used condition
+  file. Migrated automatically (once) from the old
+  `./logs/condition_file_log.json`.
+
+## Paths / logging helpers
+
+`yoru/libs/user_paths.py` centralizes these paths and configures logging:
+`get_yoru_home()`, `get_log_dir()`, `get_log_file()`, `get_state_file()`,
+`setup_logging()`, `log_exception(context, exc)`, `log_message(msg, level)`.
+It has **no** GUI/OpenCV dependency, so it is safe to import early and to
+unit-test headlessly.
+
+## Environment
+
+The primary interpreter is the conda `yoru` env
+(`miniconda3\envs\yoru\python.exe`). Bare `python` on this machine is a broken
+Windows Store stub — always launch subprocesses with `sys.executable`.

--- a/yoru/app.py
+++ b/yoru/app.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -7,6 +8,8 @@ from pathlib import Path
 from tkinter import Tk, filedialog
 
 import eel
+
+from yoru.libs.user_paths import get_state_file, log_message, setup_logging
 
 # if __name__ == "__main__":
 
@@ -37,6 +40,10 @@ def _run_gui_subprocess(command, gui_name):
     stdout, stderr = proc.communicate()
     if proc.returncode != 0:
         error_msg = stderr.strip() if stderr.strip() else stdout.strip()
+        log_message(
+            f"GUI subprocess '{gui_name}' exited with code {proc.returncode}: {error_msg}",
+            level=logging.ERROR,
+        )
         eel.displayError(gui_name, error_msg)
 
 
@@ -49,24 +56,38 @@ def _launch_gui(command, gui_name):
 
 
 def create_default_json():
-    log_dir = "./logs"
-    log_file_path = f"{log_dir}/condition_file_log.json"
-
-    # Create the directory if it does not exist
-    if not os.path.exists(log_dir):
-        os.makedirs(log_dir)
-
     default_data = {"config_file": default_condition_file_path}
-    with open(log_file_path, "w") as file:
+    with open(get_state_file(), "w") as file:
         json.dump(default_data, file)
+
+
+def _migrate_legacy_state_file(state_file):
+    """One-time migration of the pre-``~/.yoru`` state file.
+
+    Older versions stored the last-used config in
+    ``./logs/condition_file_log.json`` (relative to the working directory). If
+    that legacy file exists and the new one does not yet, copy it over so the
+    user's last selection is preserved. The legacy file is left in place.
+    """
+    legacy = Path("./logs/condition_file_log.json")
+    try:
+        if legacy.is_file() and not state_file.exists():
+            with open(legacy, "r") as f:
+                data = json.load(f)
+            with open(state_file, "w") as f:
+                json.dump(data, f)
+            log_message(f"Migrated legacy state file {legacy} -> {state_file}")
+    except Exception as e:
+        log_message(f"Legacy state migration skipped: {e}", level=logging.WARNING)
 
 
 def load_condition_file():
     global condition_file_path
-    log_file_path = "./logs/condition_file_log.json"
-    print(path_to_ab(log_file_path))
+    state_file = get_state_file()
+    _migrate_legacy_state_file(state_file)
+    print(path_to_ab(str(state_file)))
     try:
-        with open(log_file_path, "r") as file:
+        with open(state_file, "r") as file:
             data = json.load(file)
             if "config_file" in data:
                 condition_file_path = data["config_file"]
@@ -114,7 +135,7 @@ def show_file_dialog():
 
 def update_json_config_file(new_path):
     data = {"config_file": new_path}
-    with open("./logs/condition_file_log.json", "w") as file:
+    with open(get_state_file(), "w") as file:
         json.dump(data, file)
 
 
@@ -166,6 +187,7 @@ def run_config_creator_gui():
 
 
 def main():
+    setup_logging()  # write runtime logs to ~/.yoru/logs/yoru.log
     load_condition_file()  # Load the configuration file
     eel.init("web")
     eel.start("gui_home.html", size=(1024, 768), port=8889)

--- a/yoru/cli.py
+++ b/yoru/cli.py
@@ -63,9 +63,15 @@ def main(argv: list[str] | None = None) -> int:
 
 def _cmd_gui(args) -> int:
     """Launch GUI. Keep imports lazy so '--help' stays fast."""
+    # Imported here (not at module top) so '--help'/'--version' stay fast and
+    # do not create the ~/.yoru directory.
+    from yoru.libs.user_paths import log_exception, setup_logging
+    setup_logging()
+
     try:
         from yoru.app import main as app_main   # <- your existing GUI entry point
     except Exception as e:
+        log_exception("failed to import yoru.app.main", e)
         print(f"[yoru] failed to import yoru.app.main: {e}")
         return 1
 
@@ -86,5 +92,6 @@ def _cmd_gui(args) -> int:
     except SystemExit as se:
         return int(se.code or 0)
     except Exception as e:
+        log_exception("GUI crashed", e)
         print(f"[yoru] GUI crashed: {e}")
         return 1

--- a/yoru/libs/gui_error.py
+++ b/yoru/libs/gui_error.py
@@ -4,7 +4,9 @@ By having each ``*_GUI`` class inherit :class:`GuiErrorMixin`, the following
 can be handled uniformly:
 
 - On failure, write a traceback to standard error
-  (``app.py``'s ``_run_gui_subprocess`` forwards it to the home screen), and
+  (``app.py``'s ``_run_gui_subprocess`` forwards it to the home screen),
+- Append the exception (with traceback) to the persistent YORU log file
+  ``~/.yoru/logs/yoru.log`` (see :mod:`yoru.libs.user_paths`), and
 - Display the error details in a DearPyGui modal window.
 
 This generalizes the pattern first implemented in ``analysis_GUI.py``.
@@ -14,6 +16,8 @@ import sys
 import traceback
 
 import dearpygui.dearpygui as dpg
+
+from yoru.libs.user_paths import log_exception
 
 
 class GuiErrorMixin:
@@ -29,11 +33,14 @@ class GuiErrorMixin:
         method displays. The traceback written to standard error is for logging;
         note that ``app.py``'s ``_run_gui_subprocess`` only forwards it to the
         home screen when the GUI process exits with a non-zero code (i.e. it
-        crashed without catching the exception).
+        crashed without catching the exception). Independently of that, the
+        exception is always appended to ``~/.yoru/logs/yoru.log`` so it can be
+        reviewed after the fact.
         """
         detail = f"{type(exc).__name__}: {exc}"
         print(f"[ERROR] {context}: {detail}", file=sys.stderr, flush=True)
         traceback.print_exc()
+        log_exception(context, exc)  # persist to ~/.yoru/logs/yoru.log
         self._show_error_popup(context, detail)
 
     def _show_error_popup(self, context, detail):

--- a/yoru/libs/user_paths.py
+++ b/yoru/libs/user_paths.py
@@ -1,0 +1,110 @@
+"""User-directory paths and file logging for YORU.
+
+Centralizes the ``~/.yoru`` user directory used for:
+
+- persistent runtime / error logs (``~/.yoru/logs/yoru.log``), and
+- user state such as the last-used condition file
+  (``~/.yoru/condition_file_log.json``).
+
+This module intentionally has **no** GUI / OpenCV dependency so it can be
+imported early (CLI, app startup) and unit-tested headlessly. The user
+directory can be relocated with the ``YORU_HOME`` environment variable
+(defaults to ``~/.yoru``).
+"""
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+_DEFAULT_DIRNAME = ".yoru"
+_LOG_FILENAME = "yoru.log"
+_STATE_FILENAME = "condition_file_log.json"
+_LOGGER_NAME = "yoru"
+
+# Rotating file handler defaults.
+_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+_BACKUP_COUNT = 3
+
+_logging_configured = False
+
+
+def get_yoru_home() -> Path:
+    """Return the ``~/.yoru`` directory (overridable via ``YORU_HOME``), creating it."""
+    override = os.environ.get("YORU_HOME")
+    home = Path(override) if override else Path.home() / _DEFAULT_DIRNAME
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def get_log_dir() -> Path:
+    """Return ``~/.yoru/logs`` (created)."""
+    log_dir = get_yoru_home() / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir
+
+
+def get_log_file() -> Path:
+    """Return the path to the rotating log file ``~/.yoru/logs/yoru.log``."""
+    return get_log_dir() / _LOG_FILENAME
+
+
+def get_state_file() -> Path:
+    """Return the user-state file ``~/.yoru/condition_file_log.json``."""
+    return get_yoru_home() / _STATE_FILENAME
+
+
+def setup_logging(level: int = logging.INFO) -> logging.Logger:
+    """Attach a rotating file handler writing to ``~/.yoru/logs/yoru.log``.
+
+    Safe to call multiple times; the file handler is attached only once. If the
+    log file cannot be opened, logging falls back to console only rather than
+    crashing the application.
+    """
+    global _logging_configured
+    logger = logging.getLogger(_LOGGER_NAME)
+    logger.setLevel(level)
+    if _logging_configured:
+        return logger
+
+    formatter = logging.Formatter(
+        "%(asctime)s | %(levelname)-7s | %(name)s | %(message)s"
+    )
+    try:
+        handler = RotatingFileHandler(
+            get_log_file(),
+            maxBytes=_MAX_BYTES,
+            backupCount=_BACKUP_COUNT,
+            encoding="utf-8",
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    except Exception:
+        # If the log file can't be created, keep going without file logging.
+        pass
+
+    _logging_configured = True
+    return logger
+
+
+def get_logger() -> logging.Logger:
+    """Return the shared ``yoru`` logger (configuring logging on first use)."""
+    setup_logging()
+    return logging.getLogger(_LOGGER_NAME)
+
+
+def log_exception(context: str, exc: BaseException) -> None:
+    """Record an exception (with traceback) to the YORU log file."""
+    try:
+        get_logger().error("%s: %s", context, exc, exc_info=exc)
+    except Exception:
+        # Logging must never raise into the caller's error-handling path.
+        pass
+
+
+def log_message(message: str, level: int = logging.INFO) -> None:
+    """Record a plain message to the YORU log file."""
+    try:
+        get_logger().log(level, message)
+    except Exception:
+        pass


### PR DESCRIPTION
Route runtime errors and work logs to a rotating file under the user's home directory so failures can be reviewed after the fact, and move the app's user state out of the cwd-relative ./logs.

- yoru/libs/user_paths.py (new): resolves ~/.yoru (overridable via YORU_HOME) and configures a RotatingFileHandler at ~/.yoru/logs/yoru.log (5MB x3). Helpers: get_yoru_home/get_log_dir/ get_log_file/get_state_file/setup_logging/log_exception/log_message. No GUI/OpenCV dependency, so it imports early and unit-tests headlessly.

- gui_error.py: GuiErrorMixin._report_error now also appends the caught exception (with traceback) to the log file, in addition to the stderr print and the modal popup.

- app.py: call setup_logging() at startup; log GUI subprocess non-zero exits; move the last-used-config state file from ./logs/condition_file_log.json to ~/.yoru/condition_file_log.json, with a one-time migration of the legacy file.

- cli.py: set up logging when launching the GUI and log import/crash failures at the CLI level (imports stay lazy so --help/--version do not create ~/.yoru).

- CLAUDE.md (new): documents that ~/.yoru/logs/yoru.log should be checked first when a YORU run fails, plus the user-state location and helpers.

Verified: py_compile of changed files, real-dependency import check, and a headless smoke test of user_paths (log file written with traceback, idempotent setup_logging, YORU_HOME override).