### PR TITLE
Fix error-handling gaps found reviewing PR #36

### DIFF
--- a/yoru/grab_GUI.py
+++ b/yoru/grab_GUI.py
@@ -274,6 +274,18 @@ class grab_gui(GuiErrorMixin):
             dpg.enable_item("streamingChkBox")
             dpg.enable_item("frame_bar")
         except Exception as e:
+            # Roll back to a safe state so the streaming loop and frame buttons
+            # do not later operate on a broken capture (cv2.resize(None) crash).
+            if getattr(self, "vid", None) is not None:
+                self.vid.release()
+            self.vid = None
+            self.frame = None
+            self.status = False
+            if dpg.does_item_exist("streamingChkBox"):
+                dpg.set_value("streamingChkBox", False)
+                dpg.disable_item("streamingChkBox")
+            if dpg.does_item_exist("frame_bar"):
+                dpg.disable_item("frame_bar")
             self._report_error("Failed to open video file", e)
 
     # Shortcut key settings
@@ -295,9 +307,13 @@ class grab_gui(GuiErrorMixin):
         self.grab_dir = self.fd_tk.grab_dir_open()
 
     def slide_bar_cb(self):
+        if getattr(self, "vid", None) is None:
+            return
         self.current_frame_num = dpg.get_value("frame_bar")
         self.vid.set(cv2.CAP_PROP_POS_FRAMES, self.current_frame_num)
         self.status, self.frame = self.vid.read()
+        if not self.status or self.frame is None:
+            return
         self.process_frame()
 
         dpg.set_value("imwin_tag0", self.frame_to_data(self.frame_re))

--- a/yoru/realtime_yoru_GUI.py
+++ b/yoru/realtime_yoru_GUI.py
@@ -25,6 +25,7 @@ sys.path.append("../yoru")
 from yoru.libs.detection import yolo_detection
 from yoru.libs.drawing import yolo_drawing
 from yoru.libs.file_operation_realtime import file_dialog_tk
+from yoru.libs.gui_error import GuiErrorMixin
 from yoru.libs.imager import capture_streamCV2, capture_streamMSS, select_run
 from yoru.libs.init_realtime import init_asovi
 from yoru.libs.trigger import read_condition, yolo_trigger
@@ -45,7 +46,7 @@ from yoru.libs.util import loadingParam
 #     import app as YORU
 
 
-class camGUI:
+class camGUI(GuiErrorMixin):
     def __init__(self, config_file=[], m_dict={}):
         self.m_dict = m_dict
         self.t0 = m_dict["t0"]
@@ -301,8 +302,18 @@ class camGUI:
 
     def run(self):
         self.startDPG()
+        plot_error_shown = False
         while dpg.is_dearpygui_running():
-            self.plot_callback()
+            try:
+                self.plot_callback()
+                plot_error_shown = False
+            except Exception as e:
+                # Surface a display/detection error once instead of letting it
+                # crash the real-time process silently; keep rendering so the
+                # popup stays visible and the GUI can recover on the next frame.
+                if not plot_error_shown:
+                    self._report_error("Real-time display error", e)
+                    plot_error_shown = True
             dpg.render_dearpygui_frame()
             if self.m_dict["quit"]:
                 if self.m_dict["back_to_home"]:

--- a/yoru/refine_GUI.py
+++ b/yoru/refine_GUI.py
@@ -229,6 +229,18 @@ class grab_gui(GuiErrorMixin):
             dpg.enable_item("streamingChkBox")
             dpg.enable_item("frame_bar")
         except Exception as e:
+            # Roll back to a safe state so the streaming loop and frame buttons
+            # do not later operate on a broken capture (cv2.resize(None) crash).
+            if getattr(self, "vid", None) is not None:
+                self.vid.release()
+            self.vid = None
+            self.frame = None
+            self.status = False
+            if dpg.does_item_exist("streamingChkBox"):
+                dpg.set_value("streamingChkBox", False)
+                dpg.disable_item("streamingChkBox")
+            if dpg.does_item_exist("frame_bar"):
+                dpg.disable_item("frame_bar")
             self._report_error("Failed to open video file", e)
 
     # Shortcut key settings
@@ -250,9 +262,13 @@ class grab_gui(GuiErrorMixin):
         self.grab_dir = self.fd_tk.grab_dir_open()
 
     def slide_bar_cb(self):
+        if getattr(self, "vid", None) is None:
+            return
         self.current_frame_num = dpg.get_value("frame_bar")
         self.vid.set(cv2.CAP_PROP_POS_FRAMES, self.current_frame_num)
         self.status, self.frame = self.vid.read()
+        if not self.status or self.frame is None:
+            return
         self.process_frame()
 
         dpg.set_value("imwin_tag0", self.frame_to_data(self.frame_re))

--- a/yoru/train_GUI.py
+++ b/yoru/train_GUI.py
@@ -390,11 +390,27 @@ class yoru_train(GuiErrorMixin):
                 else:
                     dpg.set_value("train_eta_text", f"{s}s")
         if self.m_dict.get("training_done", False):
-            self._set_step_state("step6_state", "Complete!!")
-            dpg.set_value("train_progress_bar", 1.0)
-            dpg.set_value("train_progress_text", "Done!")
-            dpg.set_value("train_eta_text", "0s")
             self.m_dict["training_done"] = False
+            returncode = self.m_dict.get("training_returncode", 0)
+            if returncode:
+                # The training subprocess exited with a non-zero code: surface it
+                # instead of reporting a false "Complete!!".
+                tail = self.m_dict.get("train_output_tail", "")
+                message = f"Training exited with code {returncode}"
+                if tail:
+                    message += f"\n\nLast output:\n{tail}"
+                try:
+                    raise RuntimeError(message)
+                except RuntimeError as e:
+                    self._report_error("Training failed", e)
+                self._set_step_state("step6_state", "Error")
+                dpg.set_value("train_progress_text", "Failed")
+                dpg.set_value("train_eta_text", "-")
+            else:
+                self._set_step_state("step6_state", "Complete!!")
+                dpg.set_value("train_progress_bar", 1.0)
+                dpg.set_value("train_progress_text", "Done!")
+                dpg.set_value("train_eta_text", "0s")
 
     def run(self):
         self.startDPG()
@@ -727,10 +743,14 @@ class yoru_train(GuiErrorMixin):
 
         start_time = None
         start_epoch = 0
+        tail_lines = []  # keep the last output lines for error reporting
 
         for raw_line in proc.stdout:
             line = ansi_re.sub("", raw_line).rstrip()
             print(line)  # pass-through to console
+            tail_lines.append(line)
+            if len(tail_lines) > 20:
+                del tail_lines[0]
             m = torchvision_re.search(line) or ultralytics_re.match(line)
             if m:
                 current = int(m.group(1))
@@ -749,12 +769,14 @@ class yoru_train(GuiErrorMixin):
 
         proc.wait()
         self.m_dict["train_epoch"]   = self.m_dict.get("train_total_epoch", total_epochs)
+        self.m_dict["training_returncode"] = proc.returncode
+        self.m_dict["train_output_tail"]   = "\n".join(tail_lines)
         self.m_dict["training_done"] = True
 
     def run_yolov5(self):
         # train
         cmd = [
-            "python",
+            sys.executable,
             "./yoru/libs/yolov5/train.py",
             "--imgsz",
             str(self.m_dict["img"]),
@@ -800,7 +822,7 @@ class yoru_train(GuiErrorMixin):
     def run_yolo_ultralytics(self):
         """Launch YOLOv8 / YOLO11 training via the ultralytics package."""
         cmd = [
-            "python",
+            sys.executable,
             "./yoru/libs/train_ultralytics.py",
             "--weights",
             str(self.m_dict["weight"]),
@@ -848,7 +870,7 @@ class yoru_train(GuiErrorMixin):
         model_type = family_to_model[self.m_dict.get("model_family", "Faster R-CNN")]
 
         cmd = [
-            "python",
+            sys.executable,
             "./yoru/libs/train_torchvision.py",
             "--model",   model_type,
             "--data",    str(self.m_dict["yaml_path"]),


### PR DESCRIPTION
Follow-up to the exception_handling merge (#36):

- train_GUI: the three training launchers hardcoded bare "python" (the broken Store stub on this environment / an interpreter without the training deps), while d91255d had already switched the grab/labelImg launchers to sys.executable. Use sys.executable in all three. Also record the training subprocess return code in _monitor_training and branch on it in plot_callback, so a failed run surfaces an error (with the tail of the output) instead of a false "Complete!!".

- grab_GUI / refine_GUI: file_open caught an open/read failure, showed a popup and returned as if handled, but left self.vid pointing at a broken capture with streaming still enabled, so the next rendered frame crashed the GUI in cv2.resize(None). Roll back state on the error path and make slide_bar_cb defensive.

- realtime_yoru_GUI: camGUI was the only GUI excluded from the GuiErrorMixin overhaul. Inherit the mixin and report display/detection errors in the run loop instead of dying silently.