### PR TITLE
Route swallowed error paths to ~/.yoru logging

### DIFF
--- a/yoru/app.py
+++ b/yoru/app.py
@@ -93,7 +93,16 @@ def load_condition_file():
                 condition_file_path = data["config_file"]
             else:
                 condition_file_path = default_condition_file_path
-    except (FileNotFoundError, json.JSONDecodeError):
+    except FileNotFoundError:
+        # First run / no state file yet: expected, fall back to default silently.
+        condition_file_path = default_condition_file_path
+        create_default_json()  # Create the default JSON file
+    except json.JSONDecodeError as e:
+        # The state file exists but is corrupt: record the recovery.
+        log_message(
+            f"State file {state_file} is corrupt, resetting to default: {e}",
+            level=logging.WARNING,
+        )
         condition_file_path = default_condition_file_path
         create_default_json()  # Create the default JSON file
 
@@ -102,6 +111,10 @@ def load_condition_file():
 def run_cam_gui_YMH():
     global condition_file_path
     if not os.path.isfile(condition_file_path):
+        log_message(
+            f"Real-time GUI aborted: config file not found: {condition_file_path}",
+            level=logging.ERROR,
+        )
         eel.displayError("Real-time GUI", "Config file not found: " + condition_file_path)
         return
     _launch_gui(

--- a/yoru/config_creator_GUI.py
+++ b/yoru/config_creator_GUI.py
@@ -20,6 +20,7 @@ import yaml
 sys.path.append("../yoru")
 
 from yoru.libs.gui_error import GuiErrorMixin
+from yoru.libs.user_paths import log_exception
 
 
 class ConfigCreatorGUI(GuiErrorMixin):
@@ -334,6 +335,9 @@ class ConfigCreatorGUI(GuiErrorMixin):
                 dpg.set_value("cfg_trigger_class", class_names[0])
             dpg.set_value("cfg_class_loading_state", f" {len(class_names)} classes loaded")
         except Exception as e:
+            # Worker thread: avoid _report_error (modal from a non-main thread);
+            # persist to ~/.yoru/logs/yoru.log and keep the GUI status string.
+            log_exception("Failed to load classes from model", e)
             dpg.set_value("cfg_class_loading_state", f" Error: {e}")
 
     def _select_export_dir(self):

--- a/yoru/libs/create_yaml_train.py
+++ b/yoru/libs/create_yaml_train.py
@@ -1,7 +1,10 @@
 import datetime
+import logging
 import os
 
 import yaml
+
+from yoru.libs.user_paths import log_message
 
 
 class create_project:
@@ -57,6 +60,10 @@ class create_project:
                 )
             print("add class info in yaml file")
         else:
+            log_message(
+                f"add_class_info failed: config yaml not found: {file_path}",
+                logging.ERROR,
+            )
             print("failed....")
 
     def add_training_info(self):
@@ -94,4 +101,8 @@ class create_project:
                 )
             print("add class info in yaml file")
         else:
+            log_message(
+                f"add_training_info failed: config yaml not found: {file_path}",
+                logging.ERROR,
+            )
             print("failed....")

--- a/yoru/libs/file_operation_train.py
+++ b/yoru/libs/file_operation_train.py
@@ -9,6 +9,8 @@ from multiprocessing import Manager, Process
 
 import dearpygui.dearpygui as dpg
 
+from yoru.libs.user_paths import log_exception
+
 
 class file_move_random:
     def __init__(self, m_dict={}):
@@ -73,7 +75,8 @@ class file_move_random:
             try:
                 shutil.copy(source_file_label, destination_dir_label)
                 shutil.copy(source_file_image, destination_dir_image)
-            except FileNotFoundError:
+            except FileNotFoundError as e:
+                log_exception(f"Train-split copy failed for {i}", e)
                 print(f"Don't find {i} files")
 
         for i in self.move_files_dict["val"]:
@@ -84,7 +87,8 @@ class file_move_random:
             try:
                 shutil.copy(source_file_label, destination_dir_label)
                 shutil.copy(source_file_image, destination_dir_image)
-            except FileNotFoundError:
+            except FileNotFoundError as e:
+                log_exception(f"Val-split copy failed for {i}", e)
                 print(f"Don't find {i} files")
         print("complete")
 

--- a/yoru/libs/gui_error.py
+++ b/yoru/libs/gui_error.py
@@ -66,9 +66,11 @@ class GuiErrorMixin:
                     width=80,
                     callback=lambda: dpg.delete_item(tag),
                 )
-        except Exception:
-            # Even if showing the popup fails, the message remains in standard error
-            pass
+        except Exception as e:
+            # The original error was already logged by _report_error; still
+            # persist the failure of the error popup itself so a broken
+            # error-reporting UI is visible in ~/.yoru/logs/yoru.log.
+            log_exception("Failed to display error popup", e)
 
     def _safe_enable(self, tag):
         """Enable the item only if it exists (ignore failures)."""

--- a/yoru/libs/imager.py
+++ b/yoru/libs/imager.py
@@ -1,5 +1,6 @@
 import csv
 import datetime
+import logging
 import time
 import tkinter as tk
 from threading import Thread
@@ -9,6 +10,8 @@ import mss
 import numpy as np
 from PIL import Image, ImageTk
 from pynput import mouse
+
+from yoru.libs.user_paths import log_message
 
 
 class capture_streamCV2:
@@ -134,6 +137,11 @@ class capture_streamCV2:
                             self.rtesult_writer.writerows(self.m_dict["yolo_results"])
                         self.frame_count += 1
                 else:
+                    log_message(
+                        "capture_streamCV2.run: camera read failed (status=False); "
+                        "stopping capture loop",
+                        logging.ERROR,
+                    )
                     break
                 if cv2.waitKey(1) & 0xFF == ord("q"):
                     break

--- a/yoru/libs/nidaq.py
+++ b/yoru/libs/nidaq.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import time
 from enum import auto
@@ -6,6 +7,8 @@ import nidaqmx
 import numpy as np
 from nidaqmx.constants import AcquisitionType, Edge, LineGrouping
 from nidaqmx.errors import DaqError
+
+from yoru.libs.user_paths import log_message
 
 
 # Mainly for NI USB-6001 and similar type of DAQs
@@ -31,6 +34,7 @@ class dio:
             self.nCh = len(self.task.do_channels.channel_names)
             print("Configured: " + devID + "/" + port + "/" + lineCh + " (DO)")
         else:
+            log_message("Unknown NI-DAQ task type: " + taskType, logging.ERROR)
             print("Unknown Task type: " + taskType)
 
     def startAll(self):

--- a/yoru/libs/trigger.py
+++ b/yoru/libs/trigger.py
@@ -10,6 +10,7 @@ import serial.tools.list_ports
 sys.path.append("../yoru")
 
 import yoru.libs.arduino as ard
+from yoru.libs.user_paths import log_exception
 
 
 class yolo_trigger:
@@ -38,7 +39,9 @@ class yolo_trigger:
             #     time.sleep(1)
             # continue
             except Exception as e:  # Print a specific error message
+                log_exception("Trigger setup failed", e)
                 print(f"Error: {e}")
+                time.sleep(1)  # back off to avoid tight-loop log spam
                 continue
 
             self.process_triggers()
@@ -50,7 +53,8 @@ class yolo_trigger:
                 # print(self.m_dict["yolo_results"])
 
                 # trigger processing
-            except serial.serialutil.SerialException:
+            except serial.serialutil.SerialException as e:
+                log_exception("Arduino trigger serial failure", e)
                 print("Trigger failure ....")
                 time.sleep(1)
                 break
@@ -75,6 +79,7 @@ class trigger_python:
             try:
                 self.myArduino = ard.dio(comport=self.com, doCh_IDs=[self.pin])
             except PermissionError as e:
+                log_exception(f"Could not open Arduino port '{self.com}'", e)
                 print(f"Error: could not open port '{self.com}': {e}")
                 if self.myArduino:
                     self.myArduino.close()        # close method of ard.dio

--- a/yoru/train_GUI.py
+++ b/yoru/train_GUI.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import subprocess
@@ -20,6 +21,7 @@ from yoru.libs.create_yaml_train import create_project
 from yoru.libs.file_operation_train import file_dialog_tk, file_move_random
 from yoru.libs.gui_error import GuiErrorMixin
 from yoru.libs.init_train import init_train
+from yoru.libs.user_paths import log_message
 
 # import yoru.app as YORU
 
@@ -747,7 +749,12 @@ class yoru_train(GuiErrorMixin):
                     sec_per_epoch = elapsed / completed
                     self.m_dict["train_eta_seconds"] = sec_per_epoch * remaining
 
-        proc.wait()
+        returncode = proc.wait()
+        if returncode:
+            log_message(
+                f"Training subprocess exited with code {returncode}",
+                level=logging.ERROR,
+            )
         self.m_dict["train_epoch"]   = self.m_dict.get("train_total_epoch", total_epochs)
         self.m_dict["training_done"] = True
 


### PR DESCRIPTION
Follow-up to the ~/.yoru logging feature: an adversarial audit of the first-party code found 14 error-handling sites that never reached ~/.yoru/logs/yoru.log (errors swallowed with pass, print-only, or a silent continue/break in a loop). Route the real ones through log_exception / log_message. GuiErrorMixin._report_error already logs, so except blocks that call it were left untouched.

High severity (real-time / training / device loops):
- train_GUI._monitor_training: log the training subprocess's non-zero exit code instead of discarding it.
- trigger.py: log trigger-setup failure (Arduino open + plugin import, now with a 1s backoff to avoid tight-loop spam) and serial trigger failure in the real-time loop.
- imager.py: log a camera read failure (status=False) before the capture loop breaks.

Medium:
- config_creator_GUI._load_classes: log model-load failure from the worker thread (log only, no modal from a non-main thread).
- app.run_cam_gui_YMH: log the "config file not found" launch abort.
- create_yaml_train: log missing-config-yaml failures in add_class_info / add_training_info.
- trigger.py: log PermissionError opening the Arduino COM port.
- file_operation_train.move: log train/val split copy failures (missing dataset files) instead of print-only.

Low:
- app.load_condition_file: split FileNotFoundError (silent, expected first run) from json.JSONDecodeError (log a WARNING on corrupt state).
- gui_error._show_error_popup: log a failure of the error popup itself instead of swallowing it with pass.
- nidaq.dio: log an unknown DAQ task type.

Left intentionally unlogged (verified as noise, not gaps): trigger.py TypeError branch (expected "YOLO not on" state, fires ~1/s), yolo_wrapper.detect_model_type fallback (fails routinely in the healthy path), gui_error._safe_enable (best-effort UI restore, real error already logged).

Verified: py_compile + import of all changed modules, and an end-to-end test that a modified error path writes to ~/.yoru/logs/yoru.log.